### PR TITLE
feat: write tools for table and column descriptions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,8 @@
 Enable the agent to **write metadata** to OpenMetadata, not just read it.
 
 ### Metadata Enrichment
-- [ ] **Add/edit table descriptions** — PATCH table metadata with natural language
-- [ ] **Add/edit column descriptions** — PATCH column-level descriptions
+- [x] **Add/edit table descriptions** — PATCH table metadata with natural language ([#4](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/4))
+- [x] **Add/edit column descriptions** — PATCH column-level descriptions ([#4](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/4))
 - [ ] **Assign owners** to tables and assets — PATCH owner field
 
 ### Glossary Management
@@ -37,7 +37,7 @@ Enable the agent to **write metadata** to OpenMetadata, not just read it.
 - [ ] **Create/assign domains** — POST domains and associate assets to them
 
 ### Safety
-- [ ] Confirmation prompt before any write operation
+- [x] Confirmation prompt before any write operation ([#4](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/4))
 - [ ] Dry-run mode to preview changes before applying
 - [ ] Audit log of all write operations
 

--- a/app.py
+++ b/app.py
@@ -24,7 +24,9 @@ from server import (
     list_databases,
     list_glossary_terms,
     get_lineage,
-    list_domains
+    list_domains,
+    update_table_description,
+    update_column_description,
 )
 
 # Configuración
@@ -33,7 +35,8 @@ OPENMETADATA_URL = os.getenv("OPENMETADATA_URL", "http://localhost:8585")
 
 # Registro de tools: lista y lookup por nombre
 TOOLS = [search_catalog, list_tables, get_table_details, list_databases,
-         list_glossary_terms, get_lineage, list_domains]
+         list_glossary_terms, get_lineage, list_domains,
+         update_table_description, update_column_description]
 TOOLS_BY_NAME = {fn.__name__: fn for fn in TOOLS}
 
 SYSTEM_PROMPT = (
@@ -44,7 +47,12 @@ SYSTEM_PROMPT = (
     "1. Si search_catalog no devuelve resultados, usa list_tables o list_databases para descubrir nombres correctos.\n"
     "2. Si el usuario escribe mal un nombre, busca coincidencias parciales en los listados.\n"
     "3. Puedes encadenar herramientas: search → list_tables → get_table_details.\n"
-    "4. No te rindas en el primer intento. Siempre intenta al menos una estrategia alternativa antes de decir que no encontraste nada."
+    "4. No te rindas en el primer intento. Siempre intenta al menos una estrategia alternativa antes de decir que no encontraste nada.\n\n"
+    "HERRAMIENTAS DE ESCRITURA (update_table_description, update_column_description):\n"
+    "1. Antes de ejecutar una herramienta de escritura, SIEMPRE confirma con el usuario mostrando exactamente qué se va a cambiar.\n"
+    "2. Muestra: tabla/columna afectada y la nueva descripción propuesta. Pregunta '¿Confirmas el cambio?'.\n"
+    "3. Solo ejecuta la herramienta de escritura después de recibir confirmación explícita del usuario.\n"
+    "4. Después de una escritura exitosa, confirma qué se cambió."
 )
 
 MAX_TOOL_ITERATIONS = 10
@@ -165,6 +173,10 @@ with st.sidebar:
     - ¿De dónde vienen los datos de la tabla orders?
     - ¿Qué bases de datos tenemos?
     - ¿Qué dominios tiene el catálogo?
+
+    **Escritura:**
+    - Actualiza la descripción de la tabla customers a "Clientes activos del sistema"
+    - Cambia la descripción de la columna email en customers a "Correo principal del cliente"
     """)
 
     st.divider()

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,16 @@ Todos los cambios notables de este proyecto se documentan aquí.
 
 ---
 
+## [0.5.0] - 2026-03-02
+
+### Added
+- **Write tools: table & column descriptions** — Two new tools `update_table_description` and `update_column_description` allow the agent to update metadata in OpenMetadata via PATCH (JSON Patch RFC 6902). First write capabilities of the agent. ([#4](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/4))
+- **`api_patch()` helper** — New HTTP helper in `server.py` for PATCH requests with `application/json-patch+json` content type.
+- **Write safety in SYSTEM_PROMPT** — The agent now asks for user confirmation before executing any write operation, showing exactly what will change.
+- **Column not found guidance** — If the user specifies a non-existent column, the tool returns the list of available column names.
+
+---
+
 ## [0.4.0] - 2026-02-19
 
 ### Added

--- a/server.py
+++ b/server.py
@@ -44,6 +44,16 @@ def api_get(endpoint: str, params: dict = None) -> dict:
     return response.json()
 
 
+def api_patch(endpoint: str, operations: list) -> dict:
+    """Hacer PATCH request a OpenMetadata API usando JSON Patch (RFC 6902)"""
+    url = f"{OPENMETADATA_URL}/api/v1{endpoint}"
+    headers = get_headers()
+    headers["Content-Type"] = "application/json-patch+json"
+    response = httpx.patch(url, headers=headers, json=operations, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
 def strip_html(text: str) -> str:
     """Remover tags HTML de un string"""
     return re.sub(r"<[^>]+>", "", text).strip()
@@ -335,6 +345,92 @@ def list_domains(limit: int = 50) -> str:
         return "\n".join(output)
     except Exception as e:
         return f"Error listando dominios: {str(e)}"
+
+
+@mcp.tool
+def update_table_description(table_name: str, description: str) -> str:
+    """Actualizar la descripción de una tabla en OpenMetadata.
+
+    Args:
+        table_name: Nombre o FQN de la tabla
+        description: Nueva descripción para la tabla
+
+    Returns:
+        Confirmación del cambio o mensaje de error
+    """
+    try:
+        search_result = api_get("/search/query", {"q": table_name, "size": 1})
+        hits = search_result.get("hits", {}).get("hits", [])
+
+        if not hits:
+            return f"No se encontró la tabla '{table_name}'"
+
+        table_id = hits[0]["_source"].get("id")
+        fqn = hits[0]["_source"].get("fullyQualifiedName", table_name)
+        if not table_id:
+            return f"No se pudo obtener ID de la tabla '{table_name}'"
+
+        operations = [{"op": "add", "path": "/description", "value": description}]
+        api_patch(f"/tables/{table_id}", operations)
+
+        return f"Descripción de '{fqn}' actualizada a: {description}"
+    except httpx.HTTPStatusError as e:
+        return f"Error HTTP actualizando tabla: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error actualizando descripción de tabla: {str(e)}"
+
+
+@mcp.tool
+def update_column_description(table_name: str, column_name: str, description: str) -> str:
+    """Actualizar la descripción de una columna en una tabla de OpenMetadata.
+
+    Args:
+        table_name: Nombre o FQN de la tabla
+        column_name: Nombre de la columna a actualizar
+        description: Nueva descripción para la columna
+
+    Returns:
+        Confirmación del cambio o mensaje de error
+    """
+    try:
+        search_result = api_get("/search/query", {"q": table_name, "size": 1})
+        hits = search_result.get("hits", {}).get("hits", [])
+
+        if not hits:
+            return f"No se encontró la tabla '{table_name}'"
+
+        table_id = hits[0]["_source"].get("id")
+        fqn = hits[0]["_source"].get("fullyQualifiedName", table_name)
+        if not table_id:
+            return f"No se pudo obtener ID de la tabla '{table_name}'"
+
+        table = api_get(f"/tables/{table_id}")
+        columns = table.get("columns", [])
+
+        col_index = None
+        for i, col in enumerate(columns):
+            if col.get("name", "").lower() == column_name.lower():
+                col_index = i
+                break
+
+        if col_index is None:
+            available = [col.get("name", "") for col in columns]
+            return (
+                f"Columna '{column_name}' no encontrada en '{fqn}'. "
+                f"Columnas disponibles: {', '.join(available)}"
+            )
+
+        operations = [{"op": "add", "path": f"/columns/{col_index}/description", "value": description}]
+        api_patch(f"/tables/{table_id}", operations)
+
+        return (
+            f"Descripción de columna '{column_name}' en '{fqn}' "
+            f"actualizada a: {description}"
+        )
+    except httpx.HTTPStatusError as e:
+        return f"Error HTTP actualizando columna: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error actualizando descripción de columna: {str(e)}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Added `update_table_description` and `update_column_description` tools — first write capabilities via JSON Patch (RFC 6902)
- Added `api_patch()` helper in `server.py` for PATCH requests with `application/json-patch+json` content type
- SYSTEM_PROMPT updated to require user confirmation before any write operation
- Column not found returns list of available column names for guidance

## Test plan
- [x] `update_table_description` — happy path (write + verify)
- [x] `update_column_description` — happy path (write + verify)
- [x] Non-existent table — returns clear error
- [x] Non-existent column — returns available column names
- [x] Data reverted after tests (clean state)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)