### PR TITLE
feat: assign owners to tables and assets

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Enable the agent to **write metadata** to OpenMetadata, not just read it.
 ### Metadata Enrichment
 - [x] **Add/edit table descriptions** — PATCH table metadata with natural language ([#4](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/4))
 - [x] **Add/edit column descriptions** — PATCH column-level descriptions ([#4](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/4))
-- [ ] **Assign owners** to tables and assets — PATCH owner field
+- [x] **Assign owners** to tables and assets — PATCH owner field ([#8](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/8))
 
 ### Glossary Management
 - [ ] **Create glossary** — POST new glossary

--- a/app.py
+++ b/app.py
@@ -27,6 +27,9 @@ from server import (
     list_domains,
     update_table_description,
     update_column_description,
+    list_users,
+    list_teams,
+    assign_owner,
 )
 
 # Configuración
@@ -36,7 +39,8 @@ OPENMETADATA_URL = os.getenv("OPENMETADATA_URL", "http://localhost:8585")
 # Registro de tools: lista y lookup por nombre
 TOOLS = [search_catalog, list_tables, get_table_details, list_databases,
          list_glossary_terms, get_lineage, list_domains,
-         update_table_description, update_column_description]
+         update_table_description, update_column_description,
+         list_users, list_teams, assign_owner]
 TOOLS_BY_NAME = {fn.__name__: fn for fn in TOOLS}
 
 SYSTEM_PROMPT = (
@@ -48,11 +52,14 @@ SYSTEM_PROMPT = (
     "2. Si el usuario escribe mal un nombre, busca coincidencias parciales en los listados.\n"
     "3. Puedes encadenar herramientas: search → list_tables → get_table_details.\n"
     "4. No te rindas en el primer intento. Siempre intenta al menos una estrategia alternativa antes de decir que no encontraste nada.\n\n"
-    "HERRAMIENTAS DE ESCRITURA (update_table_description, update_column_description):\n"
+    "HERRAMIENTAS DE ESCRITURA (update_table_description, update_column_description, assign_owner):\n"
     "1. Antes de ejecutar una herramienta de escritura, SIEMPRE confirma con el usuario mostrando exactamente qué se va a cambiar.\n"
-    "2. Muestra: tabla/columna afectada y la nueva descripción propuesta. Pregunta '¿Confirmas el cambio?'.\n"
+    "2. Muestra: tabla/columna afectada y la nueva descripción o owner propuesto. Pregunta '¿Confirmas el cambio?'.\n"
     "3. Solo ejecuta la herramienta de escritura después de recibir confirmación explícita del usuario.\n"
-    "4. Después de una escritura exitosa, confirma qué se cambió."
+    "4. Después de una escritura exitosa, confirma qué se cambió.\n\n"
+    "ASIGNACIÓN DE OWNERS:\n"
+    "1. Si el usuario pide asignar un owner pero no especifica quién, usa list_users o list_teams para mostrar opciones.\n"
+    "2. El owner puede ser un usuario (type='user') o un equipo (type='team')."
 )
 
 MAX_TOOL_ITERATIONS = 10
@@ -177,6 +184,8 @@ with st.sidebar:
     **Escritura:**
     - Actualiza la descripción de la tabla customers a "Clientes activos del sistema"
     - Cambia la descripción de la columna email en customers a "Correo principal del cliente"
+    - ¿Qué usuarios hay disponibles?
+    - Asigna al usuario admin como owner de la tabla orders
     """)
 
     st.divider()

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@ Todos los cambios notables de este proyecto se documentan aquí.
 
 ---
 
+## [0.6.0] - 2026-03-02
+
+### Added
+- **Owner assignment tools** — Three new tools: `list_users`, `list_teams`, and `assign_owner` allow the agent to list available users/teams and assign owners to tables via PATCH. ([#8](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/8))
+- **Owner instructions in SYSTEM_PROMPT** — Agent uses `list_users`/`list_teams` to show options when user doesn't specify an owner.
+
+---
+
 ## [0.5.0] - 2026-03-02
 
 ### Added

--- a/server.py
+++ b/server.py
@@ -433,6 +433,122 @@ def update_column_description(table_name: str, column_name: str, description: st
         return f"Error actualizando descripción de columna: {str(e)}"
 
 
+@mcp.tool
+def list_users(limit: int = 50) -> str:
+    """Listar usuarios registrados en OpenMetadata.
+
+    Args:
+        limit: Máximo de usuarios a retornar
+
+    Returns:
+        Lista de usuarios con nombre y email
+    """
+    try:
+        result = api_get("/users", {"limit": limit, "isBot": False})
+        users = result.get("data", [])
+
+        if not users:
+            return "No hay usuarios registrados"
+
+        output = [f"👤 Usuarios registrados ({len(users)}):\n"]
+        for u in users:
+            name = u.get("name", "")
+            display = u.get("displayName", name)
+            email = u.get("email", "")
+            output.append(f"- {display} ({name})\n  Email: {email}")
+
+        return "\n".join(output)
+    except Exception as e:
+        return f"Error listando usuarios: {str(e)}"
+
+
+@mcp.tool
+def list_teams(limit: int = 50) -> str:
+    """Listar equipos registrados en OpenMetadata.
+
+    Args:
+        limit: Máximo de equipos a retornar
+
+    Returns:
+        Lista de equipos con nombre y descripción
+    """
+    try:
+        result = api_get("/teams", {"limit": limit})
+        teams = result.get("data", [])
+
+        if not teams:
+            return "No hay equipos registrados"
+
+        output = [f"👥 Equipos registrados ({len(teams)}):\n"]
+        for t in teams:
+            name = t.get("name", "")
+            display = t.get("displayName", name)
+            desc = strip_html(t.get("description", "Sin descripción"))[:80]
+            team_type = t.get("teamType", "")
+            output.append(f"- {display} ({name})\n  Tipo: {team_type}\n  {desc}")
+
+        return "\n".join(output)
+    except Exception as e:
+        return f"Error listando equipos: {str(e)}"
+
+
+@mcp.tool
+def assign_owner(table_name: str, owner_name: str, owner_type: str = "user") -> str:
+    """Asignar un owner (usuario o equipo) a una tabla en OpenMetadata.
+
+    Args:
+        table_name: Nombre o FQN de la tabla
+        owner_name: Nombre del usuario o equipo a asignar como owner
+        owner_type: Tipo de owner: "user" o "team"
+
+    Returns:
+        Confirmación del cambio o mensaje de error
+    """
+    try:
+        if owner_type not in ("user", "team"):
+            return f"owner_type debe ser 'user' o 'team', recibido: '{owner_type}'"
+
+        # Find owner by name
+        endpoint = "/users" if owner_type == "user" else "/teams"
+        try:
+            owner = api_get(f"{endpoint}/name/{owner_name}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                # List available options for guidance
+                available = api_get(endpoint, {"limit": 50})
+                names = [item.get("name", "") for item in available.get("data", [])]
+                entity_label = "usuarios" if owner_type == "user" else "equipos"
+                return (
+                    f"{owner_type.capitalize()} '{owner_name}' no encontrado. "
+                    f"{entity_label.capitalize()} disponibles: {', '.join(names)}"
+                )
+            raise
+
+        owner_id = owner.get("id")
+
+        # Find table
+        search_result = api_get("/search/query", {"q": table_name, "size": 1})
+        hits = search_result.get("hits", {}).get("hits", [])
+
+        if not hits:
+            return f"No se encontró la tabla '{table_name}'"
+
+        table_id = hits[0]["_source"].get("id")
+        fqn = hits[0]["_source"].get("fullyQualifiedName", table_name)
+        if not table_id:
+            return f"No se pudo obtener ID de la tabla '{table_name}'"
+
+        operations = [{"op": "add", "path": "/owners", "value": [{"id": owner_id, "type": owner_type}]}]
+        api_patch(f"/tables/{table_id}", operations)
+
+        owner_display = owner.get("displayName", owner_name)
+        return f"Owner de '{fqn}' asignado a: {owner_display} ({owner_type})"
+    except httpx.HTTPStatusError as e:
+        return f"Error HTTP asignando owner: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error asignando owner: {str(e)}"
+
+
 if __name__ == "__main__":
     if not OPENMETADATA_TOKEN:
         print("⚠️  ADVERTENCIA: OPENMETADATA_TOKEN no está configurado")


### PR DESCRIPTION
## Summary
- Added `list_users` and `list_teams` read tools to discover available owners
- Added `assign_owner` write tool to assign user or team as table owner via PATCH `/owners`
- SYSTEM_PROMPT updated with owner assignment instructions and discovery strategy
- `list_users` filters out bots by default (`isBot: False`)

## Test plan
- [x] `list_users` — returns human users (admin, ronaldmego)
- [x] `list_teams` — returns teams with type
- [x] `assign_owner` user — happy path (assign admin to table)
- [x] `assign_owner` team Organization — correctly returns API error (Organization type can't own, only Group)
- [x] Non-existent user — lists available users
- [x] Non-existent table — clear error message
- [x] Invalid owner_type — validation error
- [x] Data reverted after tests (clean state)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)