### PR TITLE
feat: glossary management tools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,9 +28,9 @@ Enable the agent to **write metadata** to OpenMetadata, not just read it.
 - [x] **Assign owners** to tables and assets — PATCH owner field ([#8](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/8))
 
 ### Glossary Management
-- [ ] **Create glossary** — POST new glossary
-- [ ] **Create glossary terms** — POST terms with definitions and synonyms
-- [ ] **Link glossary terms to assets** — Associate terms with tables/columns
+- [x] **Create glossary** — POST new glossary ([#10](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/10))
+- [x] **Create glossary terms** — POST terms with definitions and synonyms ([#10](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/10))
+- [x] **Link glossary terms to assets** — Associate terms with tables/columns ([#10](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/10))
 
 ### Classification & Organization
 - [ ] **Create/assign tags** — POST tags and PATCH them onto assets

--- a/app.py
+++ b/app.py
@@ -30,6 +30,9 @@ from server import (
     list_users,
     list_teams,
     assign_owner,
+    create_glossary,
+    create_glossary_term,
+    link_glossary_term,
 )
 
 # Configuración
@@ -40,7 +43,8 @@ OPENMETADATA_URL = os.getenv("OPENMETADATA_URL", "http://localhost:8585")
 TOOLS = [search_catalog, list_tables, get_table_details, list_databases,
          list_glossary_terms, get_lineage, list_domains,
          update_table_description, update_column_description,
-         list_users, list_teams, assign_owner]
+         list_users, list_teams, assign_owner,
+         create_glossary, create_glossary_term, link_glossary_term]
 TOOLS_BY_NAME = {fn.__name__: fn for fn in TOOLS}
 
 SYSTEM_PROMPT = (
@@ -59,7 +63,12 @@ SYSTEM_PROMPT = (
     "4. Después de una escritura exitosa, confirma qué se cambió.\n\n"
     "ASIGNACIÓN DE OWNERS:\n"
     "1. Si el usuario pide asignar un owner pero no especifica quién, usa list_users o list_teams para mostrar opciones.\n"
-    "2. El owner puede ser un usuario (type='user') o un equipo (type='team')."
+    "2. El owner puede ser un usuario (type='user') o un equipo (type='team').\n\n"
+    "GESTIÓN DE GLOSARIOS:\n"
+    "1. Para crear un glosario: usa create_glossary con nombre (sin espacios, usar guiones) y descripción.\n"
+    "2. Para crear términos: primero verifica que el glosario existe, luego usa create_glossary_term.\n"
+    "3. Para vincular un término a una tabla: usa link_glossary_term con el FQN del término (formato: glosario.termino).\n"
+    "4. Si el usuario no recuerda los glosarios disponibles, usa list_glossary_terms para mostrarlos."
 )
 
 MAX_TOOL_ITERATIONS = 10
@@ -186,6 +195,11 @@ with st.sidebar:
     - Cambia la descripción de la columna email en customers a "Correo principal del cliente"
     - ¿Qué usuarios hay disponibles?
     - Asigna al usuario admin como owner de la tabla orders
+
+    **Glosario:**
+    - Crea un glosario llamado "negocio" con descripción "Términos de negocio"
+    - Agrega el término "cliente" al glosario negocio
+    - Vincula el término negocio.cliente a la tabla customers
     """)
 
     st.divider()

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@ Todos los cambios notables de este proyecto se documentan aquí.
 
 ---
 
+## [0.7.0] - 2026-03-02
+
+### Added
+- **Glossary management tools** — Three new tools: `create_glossary`, `create_glossary_term`, and `link_glossary_term` allow the agent to create glossaries, add terms with definitions and synonyms, and link terms to tables as tags. ([#10](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/10))
+- **`api_post()` helper** — New HTTP helper in `server.py` for POST requests to create entities.
+- **Glossary instructions in SYSTEM_PROMPT** — Agent guided on glossary creation workflow and term FQN format.
+
+---
+
 ## [0.6.0] - 2026-03-02
 
 ### Added

--- a/server.py
+++ b/server.py
@@ -54,6 +54,14 @@ def api_patch(endpoint: str, operations: list) -> dict:
     return response.json()
 
 
+def api_post(endpoint: str, payload: dict) -> dict:
+    """Hacer POST request a OpenMetadata API"""
+    url = f"{OPENMETADATA_URL}/api/v1{endpoint}"
+    response = httpx.post(url, headers=get_headers(), json=payload, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
 def strip_html(text: str) -> str:
     """Remover tags HTML de un string"""
     return re.sub(r"<[^>]+>", "", text).strip()
@@ -547,6 +555,139 @@ def assign_owner(table_name: str, owner_name: str, owner_type: str = "user") -> 
         return f"Error HTTP asignando owner: {e.response.status_code} - {e.response.text}"
     except Exception as e:
         return f"Error asignando owner: {str(e)}"
+
+
+@mcp.tool
+def create_glossary(name: str, description: str, display_name: str = None) -> str:
+    """Crear un nuevo glosario en OpenMetadata.
+
+    Args:
+        name: Nombre del glosario (sin espacios, usar guiones)
+        description: Descripción del glosario
+        display_name: Nombre para mostrar (opcional, usa name si no se especifica)
+
+    Returns:
+        Confirmación de creación o mensaje de error
+    """
+    try:
+        payload = {
+            "name": name,
+            "displayName": display_name or name,
+            "description": description,
+        }
+        result = api_post("/glossaries", payload)
+        fqn = result.get("fullyQualifiedName", name)
+        return f"Glosario '{fqn}' creado exitosamente"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 409:
+            return f"Ya existe un glosario con el nombre '{name}'"
+        return f"Error HTTP creando glosario: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error creando glosario: {str(e)}"
+
+
+@mcp.tool
+def create_glossary_term(
+    glossary_name: str,
+    term_name: str,
+    description: str,
+    synonyms: list[str] = None,
+) -> str:
+    """Crear un nuevo término en un glosario de OpenMetadata.
+
+    Args:
+        glossary_name: Nombre o FQN del glosario donde agregar el término
+        term_name: Nombre del término (sin espacios, usar guiones)
+        description: Definición del término
+        synonyms: Lista de sinónimos opcionales
+
+    Returns:
+        Confirmación de creación o mensaje de error
+    """
+    try:
+        # Verify glossary exists
+        try:
+            api_get(f"/glossaries/name/{glossary_name}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                available = api_get("/glossaries", {"limit": 50})
+                names = [g.get("name", "") for g in available.get("data", [])]
+                if names:
+                    return (
+                        f"Glosario '{glossary_name}' no encontrado. "
+                        f"Glosarios disponibles: {', '.join(names)}"
+                    )
+                return f"Glosario '{glossary_name}' no encontrado. No hay glosarios creados."
+            raise
+
+        payload = {
+            "name": term_name,
+            "description": description,
+            "glossary": glossary_name,
+        }
+        if synonyms:
+            payload["synonyms"] = synonyms
+
+        result = api_post("/glossaryTerms", payload)
+        fqn = result.get("fullyQualifiedName", term_name)
+        syn_str = f" (sinónimos: {', '.join(synonyms)})" if synonyms else ""
+        return f"Término '{fqn}' creado exitosamente{syn_str}"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 409:
+            return f"Ya existe un término '{term_name}' en el glosario '{glossary_name}'"
+        return f"Error HTTP creando término: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error creando término de glosario: {str(e)}"
+
+
+@mcp.tool
+def link_glossary_term(table_name: str, term_fqn: str) -> str:
+    """Vincular un término de glosario a una tabla como tag.
+
+    Args:
+        table_name: Nombre o FQN de la tabla
+        term_fqn: FQN del término de glosario (ej: "mi-glosario.mi-termino")
+
+    Returns:
+        Confirmación del vínculo o mensaje de error
+    """
+    try:
+        # Find table
+        search_result = api_get("/search/query", {"q": table_name, "size": 1})
+        hits = search_result.get("hits", {}).get("hits", [])
+
+        if not hits:
+            return f"No se encontró la tabla '{table_name}'"
+
+        table_id = hits[0]["_source"].get("id")
+        table_fqn = hits[0]["_source"].get("fullyQualifiedName", table_name)
+        if not table_id:
+            return f"No se pudo obtener ID de la tabla '{table_name}'"
+
+        # Verify the glossary term exists
+        try:
+            api_get(f"/glossaryTerms/name/{term_fqn}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return f"Término de glosario '{term_fqn}' no encontrado. Usa el formato 'glosario.termino'."
+            raise
+
+        operations = [{
+            "op": "add",
+            "path": "/tags/0",
+            "value": {
+                "tagFQN": term_fqn,
+                "source": "Glossary",
+                "labelType": "Manual",
+            },
+        }]
+        api_patch(f"/tables/{table_id}", operations)
+
+        return f"Término '{term_fqn}' vinculado a la tabla '{table_fqn}'"
+    except httpx.HTTPStatusError as e:
+        return f"Error HTTP vinculando término: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error vinculando término de glosario: {str(e)}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Added `create_glossary` — POST new glossary with name, description, display name
- Added `create_glossary_term` — POST new term with definition and synonyms to a glossary
- Added `link_glossary_term` — associate a glossary term to a table as a tag via PATCH
- Added `api_post()` helper for POST requests
- SYSTEM_PROMPT updated with glossary workflow and FQN format guidance

## Test plan
- [x] `create_glossary` — creates glossary successfully
- [x] Duplicate glossary — returns "already exists" message
- [x] `create_glossary_term` — creates term with synonyms
- [x] Duplicate term — returns clear API error
- [x] Term in non-existent glossary — lists available glossaries
- [x] `link_glossary_term` — links term to table as tag
- [x] Non-existent term — returns format guidance
- [x] Non-existent table — clear error message
- [x] Data cleaned up after tests

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)