### PR TITLE
feat: classification/tag and domain tools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,8 +33,8 @@ Enable the agent to **write metadata** to OpenMetadata, not just read it.
 - [x] **Link glossary terms to assets** — Associate terms with tables/columns ([#10](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/10))
 
 ### Classification & Organization
-- [ ] **Create/assign tags** — POST tags and PATCH them onto assets
-- [ ] **Create/assign domains** — POST domains and associate assets to them
+- [x] **Create/assign tags** — POST tags and PATCH them onto assets ([#12](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/12))
+- [x] **Create/assign domains** — POST domains; table assignment deferred (OM 1.11.7 PATCH limitation) ([#12](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/12))
 
 ### Safety
 - [x] Confirmation prompt before any write operation ([#4](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/4))

--- a/app.py
+++ b/app.py
@@ -33,6 +33,10 @@ from server import (
     create_glossary,
     create_glossary_term,
     link_glossary_term,
+    create_classification,
+    create_tag,
+    assign_tag,
+    create_domain,
 )
 
 # Configuración
@@ -44,7 +48,8 @@ TOOLS = [search_catalog, list_tables, get_table_details, list_databases,
          list_glossary_terms, get_lineage, list_domains,
          update_table_description, update_column_description,
          list_users, list_teams, assign_owner,
-         create_glossary, create_glossary_term, link_glossary_term]
+         create_glossary, create_glossary_term, link_glossary_term,
+         create_classification, create_tag, assign_tag, create_domain]
 TOOLS_BY_NAME = {fn.__name__: fn for fn in TOOLS}
 
 SYSTEM_PROMPT = (
@@ -68,7 +73,14 @@ SYSTEM_PROMPT = (
     "1. Para crear un glosario: usa create_glossary con nombre (sin espacios, usar guiones) y descripción.\n"
     "2. Para crear términos: primero verifica que el glosario existe, luego usa create_glossary_term.\n"
     "3. Para vincular un término a una tabla: usa link_glossary_term con el FQN del término (formato: glosario.termino).\n"
-    "4. Si el usuario no recuerda los glosarios disponibles, usa list_glossary_terms para mostrarlos."
+    "4. Si el usuario no recuerda los glosarios disponibles, usa list_glossary_terms para mostrarlos.\n\n"
+    "CLASIFICACIONES Y TAGS:\n"
+    "1. Para crear un tag, primero necesitas una clasificación (categoría). Usa create_classification.\n"
+    "2. Luego crea el tag dentro de la clasificación con create_tag.\n"
+    "3. Asigna el tag a una tabla con assign_tag usando el FQN (formato: clasificacion.tag).\n\n"
+    "DOMINIOS:\n"
+    "1. Usa create_domain para crear dominios de datos. Tipos válidos: Aggregate, Consumer Aligned, Source Aligned.\n"
+    "2. La asignación de dominios a tablas se realiza desde la UI de OpenMetadata."
 )
 
 MAX_TOOL_ITERATIONS = 10
@@ -200,6 +212,12 @@ with st.sidebar:
     - Crea un glosario llamado "negocio" con descripción "Términos de negocio"
     - Agrega el término "cliente" al glosario negocio
     - Vincula el término negocio.cliente a la tabla customers
+
+    **Tags y dominios:**
+    - Crea una clasificación llamada "importancia"
+    - Crea el tag "critico" en la clasificación importancia
+    - Asigna el tag importancia.critico a la tabla orders
+    - Crea un dominio "ventas" de tipo Aggregate
     """)
 
     st.divider()

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@ Todos los cambios notables de este proyecto se documentan aquí.
 
 ---
 
+## [0.8.0] - 2026-03-02
+
+### Added
+- **Classification & tag tools** — `create_classification`, `create_tag`, `assign_tag` allow creating tag categories, tags, and assigning them to tables. ([#12](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/12))
+- **Domain creation tool** — `create_domain` creates data domains (Aggregate, Consumer Aligned, Source Aligned). Domain-to-table assignment deferred due to OM 1.11.7 PATCH limitation. ([#12](https://github.com/ronaldmego/openmetadata-mcp-agent/issues/12))
+- **Tag/domain instructions in SYSTEM_PROMPT** — Agent guided on classification→tag→assign workflow and domain types.
+
+---
+
 ## [0.7.0] - 2026-03-02
 
 ### Added

--- a/server.py
+++ b/server.py
@@ -690,6 +690,153 @@ def link_glossary_term(table_name: str, term_fqn: str) -> str:
         return f"Error vinculando término de glosario: {str(e)}"
 
 
+@mcp.tool
+def create_classification(name: str, description: str) -> str:
+    """Crear una nueva clasificación (categoría de tags) en OpenMetadata.
+
+    Args:
+        name: Nombre de la clasificación (sin espacios, usar guiones)
+        description: Descripción de la clasificación
+
+    Returns:
+        Confirmación de creación o mensaje de error
+    """
+    try:
+        result = api_post("/classifications", {"name": name, "description": description})
+        return f"Clasificación '{result.get('name')}' creada exitosamente"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 409:
+            return f"Ya existe una clasificación con el nombre '{name}'"
+        return f"Error HTTP creando clasificación: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error creando clasificación: {str(e)}"
+
+
+@mcp.tool
+def create_tag(classification_name: str, tag_name: str, description: str) -> str:
+    """Crear un nuevo tag dentro de una clasificación en OpenMetadata.
+
+    Args:
+        classification_name: Nombre de la clasificación donde crear el tag
+        tag_name: Nombre del tag (sin espacios, usar guiones)
+        description: Descripción del tag
+
+    Returns:
+        Confirmación de creación o mensaje de error
+    """
+    try:
+        # Verify classification exists
+        try:
+            api_get(f"/classifications/name/{classification_name}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                available = api_get("/classifications", {"limit": 50})
+                names = [c.get("name", "") for c in available.get("data", [])]
+                return (
+                    f"Clasificación '{classification_name}' no encontrada. "
+                    f"Clasificaciones disponibles: {', '.join(names)}"
+                )
+            raise
+
+        payload = {
+            "name": tag_name,
+            "description": description,
+            "classification": classification_name,
+        }
+        result = api_post("/tags", payload)
+        fqn = result.get("fullyQualifiedName", f"{classification_name}.{tag_name}")
+        return f"Tag '{fqn}' creado exitosamente"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 409:
+            return f"Ya existe un tag '{tag_name}' en la clasificación '{classification_name}'"
+        return f"Error HTTP creando tag: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error creando tag: {str(e)}"
+
+
+@mcp.tool
+def assign_tag(table_name: str, tag_fqn: str) -> str:
+    """Asignar un tag a una tabla en OpenMetadata.
+
+    Args:
+        table_name: Nombre o FQN de la tabla
+        tag_fqn: FQN del tag (ej: "mi-clasificacion.mi-tag")
+
+    Returns:
+        Confirmación de la asignación o mensaje de error
+    """
+    try:
+        # Find table
+        search_result = api_get("/search/query", {"q": table_name, "size": 1})
+        hits = search_result.get("hits", {}).get("hits", [])
+
+        if not hits:
+            return f"No se encontró la tabla '{table_name}'"
+
+        table_id = hits[0]["_source"].get("id")
+        table_fqn = hits[0]["_source"].get("fullyQualifiedName", table_name)
+        if not table_id:
+            return f"No se pudo obtener ID de la tabla '{table_name}'"
+
+        # Verify tag exists
+        try:
+            api_get(f"/tags/name/{tag_fqn}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return f"Tag '{tag_fqn}' no encontrado. Usa el formato 'clasificacion.tag'."
+            raise
+
+        operations = [{
+            "op": "add",
+            "path": "/tags/0",
+            "value": {
+                "tagFQN": tag_fqn,
+                "source": "Classification",
+                "labelType": "Manual",
+            },
+        }]
+        api_patch(f"/tables/{table_id}", operations)
+
+        return f"Tag '{tag_fqn}' asignado a la tabla '{table_fqn}'"
+    except httpx.HTTPStatusError as e:
+        return f"Error HTTP asignando tag: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error asignando tag: {str(e)}"
+
+
+@mcp.tool
+def create_domain(name: str, description: str, domain_type: str = "Aggregate") -> str:
+    """Crear un nuevo dominio de datos en OpenMetadata.
+
+    Args:
+        name: Nombre del dominio (sin espacios, usar guiones)
+        description: Descripción del dominio
+        domain_type: Tipo de dominio: "Aggregate", "Consumer Aligned", o "Source Aligned"
+
+    Returns:
+        Confirmación de creación o mensaje de error
+    """
+    try:
+        valid_types = ("Aggregate", "Consumer Aligned", "Source Aligned")
+        if domain_type not in valid_types:
+            return f"domain_type debe ser uno de: {', '.join(valid_types)}"
+
+        payload = {
+            "name": name,
+            "description": description,
+            "domainType": domain_type,
+        }
+        result = api_post("/domains", payload)
+        fqn = result.get("fullyQualifiedName", name)
+        return f"Dominio '{fqn}' creado exitosamente (tipo: {domain_type})"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 409:
+            return f"Ya existe un dominio con el nombre '{name}'"
+        return f"Error HTTP creando dominio: {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error creando dominio: {str(e)}"
+
+
 if __name__ == "__main__":
     if not OPENMETADATA_TOKEN:
         print("⚠️  ADVERTENCIA: OPENMETADATA_TOKEN no está configurado")


### PR DESCRIPTION
## Summary
- Added `create_classification` — POST new tag classification (category)
- Added `create_tag` — POST new tag under a classification
- Added `assign_tag` — PATCH tag onto a table via `/tags`
- Added `create_domain` — POST new data domain (Aggregate, Consumer Aligned, Source Aligned)
- SYSTEM_PROMPT updated with classification→tag→assign workflow and domain types
- **Note:** Domain-to-table assignment deferred — OM 1.11.7 returns 500 on PATCH `/domain`

## Test plan
- [x] `create_classification` — creates successfully
- [x] Duplicate classification — "already exists"
- [x] `create_tag` — creates under classification
- [x] Duplicate tag — clear error
- [x] Tag in non-existent classification — lists available
- [x] `assign_tag` — assigns to table
- [x] Non-existent tag — format guidance
- [x] `create_domain` — creates with valid type
- [x] Duplicate domain — "already exists"
- [x] Invalid domain type — validation error
- [x] Data cleaned up after tests

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)